### PR TITLE
add support to read EXTERNAL_URL_<>

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ See [Service Discovery](https://clever.atlassian.net/wiki/spaces/ENG/pages/11668
   - disc.**proto_host**() - returns (\<proto\>://\<host\>)
   - disc.**url**() - returns the url (\<proto\>://\<host\>:\<port\>)
 
+- discEx = **discoveryExternal**(\<url\>)
+  - discEx.**url**() - returns the url (\<proto\>://\<host\>:\<port\>)
+
 ### Install and import
 
 ```bash
@@ -22,6 +25,7 @@ npm install --save clever-discovery
 
 ```coffee
 discovery = require "clever-discovery"
+discoveryExternal = require "clever-discovery"
 ```
 
 ### Examples
@@ -33,6 +37,9 @@ try gearman_url = disc_gearman.url() catch err then cb(err)
 disc_systemic = discovery("systemic", "thrift")
 try systemic_host = disc_systemic.host() catch err then cb(err)
 try systemic_port = disc_systemic.port() catch err then cb(err)
+
+disc_clever_com = discoveryExternal("clever.com")
+try clever_com_url = disc_clever_com.url()
 ```
 
 To see what interfaces a Clever service exposes, check its launch yaml. You should see one or more exposes listed, and the `name` of the expose is used as the `interface` value in the discovery client.

--- a/__tests__/discovery.test.ts
+++ b/__tests__/discovery.test.ts
@@ -16,6 +16,8 @@ const pairs = {
   SERVICE_MISSING_PORT_API_PROTO: "missingport.proto",
   SERVICE_MISSING_PORT_API_HOST: "example.com",
   SERVICE_MISSING_PROTO_AND_HOST_FOOBAR_PORT: "8000",
+  EXTERNAL_URL_CLEVER_COM: "https://clever.com:443",
+  EXTERNAL_URL_API_CLEVER_COM: "https://api.clever.com:443",
 };
 
 describe("discovery", () => {
@@ -95,6 +97,14 @@ describe("discovery", () => {
     assert.throws(() => disc.port(), expected_error);
     assert.throws(() => disc.host_port(), expected_error);
     assert.throws(() => disc.url(), expected_error);
+  });
+  it("test external url", () => {
+    const disc = discovery("clever.com");
+    assert.equal(disc.external_url(), "https://clever.com:443");
+  });
+  it("test complex external url", () => {
+    const disc = discovery("api.clever.com");
+    assert.equal(disc.external_url(), "https://api.clever.com:443");
   });
   return it("test expect error on missing two vars", () => {
     const disc = discovery("missing-proto-and-host", "foobar");

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,17 @@
-function template(service_name: string, interface_name: string, value: string) {
+function template_service(service_name: string, interface_name?: string, value?: string) {
+  if (interface_name === undefined || interface_name === "") {
+    throw new Error("interface_name is required");
+  }
+
+  if (value === undefined || value === "") {
+    throw new Error("value is required");
+  }
+
   return `SERVICE_${service_name}_${interface_name}_${value}`;
+}
+
+function template_external(url: string) {
+  return `EXTERNAL_URL_${url.toUpperCase().replace(/\./g, "_")}`;
 }
 
 function get_var(env_var: string) {
@@ -11,17 +23,17 @@ function get_var(env_var: string) {
   return val;
 }
 
-const discovery = (service_name: string, interface_name: string) => ({
+const discovery = (service_name_or_url: string, interface_name?: string) => ({
   proto() {
-    return get_var(template(service_name, interface_name, "PROTO"));
+    return get_var(template_service(service_name_or_url, interface_name, "PROTO"));
   },
 
   host() {
-    return get_var(template(service_name, interface_name, "HOST"));
+    return get_var(template_service(service_name_or_url, interface_name, "HOST"));
   },
 
   port() {
-    return get_var(template(service_name, interface_name, "PORT"));
+    return get_var(template_service(service_name_or_url, interface_name, "PORT"));
   },
 
   proto_host() {
@@ -34,6 +46,13 @@ const discovery = (service_name: string, interface_name: string) => ({
 
   url() {
     return `${this.proto()}://${this.host()}:${this.port()}`;
+  },
+
+  external_url() {
+    if (interface_name !== undefined && interface_name !== "") {
+      throw new Error("interface_name should not be provided");
+    }
+    return get_var(template_external(service_name_or_url));
   },
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-discovery",
-  "version": "0.0.8",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-discovery",
-  "version": "0.0.9",
+  "version": "0.1.0",
   "description": "Node client library for service discovery",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
#JIRA

https://clever.atlassian.net/browse/INFRANG-6371

# Overview
We are moving away from `discovery.URL("app","external")` to a new system. Lets update discovery-{go,node,python} to support the new setup.

Now instead of setting `discovery("clever-com-router", "external").url()` and in some cases doing different things in dev and prod, users will just do `discovery("clever.com").external_url()`.

Note that the second argument to discovery is now optional but we are validating that it is set or not set in the correct places

# Testing
Added a new unit test that covers the added code.