### PR TITLE
export type and go back to exporting commonJS as most of clever doesn't use ESM

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -45,4 +45,7 @@ const external_url = (input_url: string) => {
   return get_var(template_external_url(input_url));
 };
 
-export { discovery, external_url };
+type discoveryMethod = keyof ReturnType<typeof discovery>;
+type externalUrlMethod = ReturnType<typeof external_url>;
+
+export { discovery, external_url, discoveryMethod, externalUrlMethod };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clever-discovery",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clever-discovery",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "ISC",
       "devDependencies": {
         "@eslint/js": "^9.9.1",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
   "name": "clever-discovery",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Node client library for service discovery",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "type": "module",
   "scripts": {
     "build": "tsc --dist",
     "test": "jest"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "module": "NodeNext",
+        "module": "CommonJS",
         "target": "ESNext",
         "strict": true,
         "lib": ["ESNext"],


### PR DESCRIPTION
# Jira

https://clever.atlassian.net/browse/INFRANG-6371

# Overview

Follow up to #26. In that PR we updated this repo to a ESM module but that is causing errors like
```
    /Users/tanmay.sardesai/go/src/github.com/Clever/fox/node_modules/clever-discovery/dist/index.js:38
    export { discovery, external_url };
    ^^^^^^

    SyntaxError: Unexpected token 'export'
````

Lets reset the library to output a CommonJS module.

I also re-added the type export as it is used in family-portal but was removed in #26.

# Testing

Tested this build against fox, skilljar-auth and family-portal using `npm link` 