### PR TITLE
add support for ExternalProtoHost. breaking api

### DIFF
--- a/__tests__/discovery.test.ts
+++ b/__tests__/discovery.test.ts
@@ -1,5 +1,5 @@
 import * as assert from "assert";
-import { discovery, external_url } from "../lib/index";
+import { discovery, external } from "../lib/index";
 
 const pairs = {
   SERVICE_REDIS_TCP_PROTO: "tcp",
@@ -97,12 +97,14 @@ describe("discovery", () => {
     assert.throws(() => disc.url(), expected_error);
   });
   it("test external url", () => {
-    // const disc = external_url("clever.com");
-    assert.equal(external_url("clever.com"), "https://clever.com:443");
+    const ex_disc = external("clever.com");
+    assert.equal(ex_disc.url(), "https://clever.com:443");
+    assert.equal(ex_disc.proto_host(), "https://clever.com");
   });
   it("test complex external url", () => {
-    // const disc = external_url("api.clever.com");
-    assert.equal(external_url("api.clever.com"), "https://api.clever.com:443");
+    const ex_disc = external("api.clever.com");
+    assert.equal(ex_disc.url(), "https://api.clever.com:443");
+    assert.equal(ex_disc.proto_host(), "https://api.clever.com");
   });
   return it("test expect error on missing two vars", () => {
     const disc = discovery("missing-proto-and-host", "foobar");

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -41,11 +41,24 @@ const discovery = (service_name: string, interface_name: string) => ({
   },
 });
 
-const external_url = (input_url: string) => {
-  return get_var(template_external_url(input_url));
-};
+const external = (input_url: string) => ({
+  url() {
+    return get_var(template_external_url(input_url));
+  },
+
+  proto_host() {
+    return trimSuffix(get_var(template_external_url(input_url)), ":443");
+  },
+});
 
 type discoveryMethod = keyof ReturnType<typeof discovery>;
-type externalUrlMethod = ReturnType<typeof external_url>;
+type externalMethod = ReturnType<typeof external>;
 
-export { discovery, external_url, discoveryMethod, externalUrlMethod };
+export { discovery, external, discoveryMethod, externalMethod };
+
+function trimSuffix(str: string, suffix: string) {
+  if (str.endsWith(suffix)) {
+    return str.slice(0, str.lastIndexOf(suffix));
+  }
+  return str;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clever-discovery",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clever-discovery",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "ISC",
       "devDependencies": {
         "@eslint/js": "^9.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clever-discovery",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Node client library for service discovery",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
# Jira
https://clever.atlassian.net/browse/INFRANG-6430

# Overview
This is a followup from #43 rollout.

In flare-1694 we found out that some apps requires a url without port number set. Instead of trimming the suffix in all repos its better to just expose that via discovery

Instead of adding an external_proto_host(). I decided to break the api and make it similar to how discovery is setup

# Testing
added a unit test

