### PR TITLE
[INFRANG-6523] fix: update template_external_url to replace hyphens with underscores

### DIFF
--- a/__tests__/discovery.test.ts
+++ b/__tests__/discovery.test.ts
@@ -18,6 +18,7 @@ const pairs = {
   SERVICE_MISSING_PROTO_AND_HOST_FOOBAR_PORT: "8000",
   EXTERNAL_URL_CLEVER_COM: "https://clever.com:443",
   EXTERNAL_URL_API_CLEVER_COM: "https://api.clever.com:443",
+  EXTERNAL_URL_DIAGNOSTICS_APP_CLEVER_COM: "https://diagnostics-app.clever.com:443",
 };
 
 describe("discovery", () => {
@@ -109,6 +110,13 @@ describe("discovery", () => {
     assert.equal(ex_disc.proto_host(), "https://api.clever.com");
     assert.equal(ex_disc.host(), "api.clever.com");
     assert.equal(ex_disc.host_port(), "api.clever.com:443");
+  });
+  it("test external url with hyphens", () => {
+    const ex_disc = external("diagnostics-app.clever.com");
+    assert.equal(ex_disc.url(), "https://diagnostics-app.clever.com:443");
+    assert.equal(ex_disc.proto_host(), "https://diagnostics-app.clever.com");
+    assert.equal(ex_disc.host(), "diagnostics-app.clever.com");
+    assert.equal(ex_disc.host_port(), "diagnostics-app.clever.com:443");
   });
   return it("test expect error on missing two vars", () => {
     const disc = discovery("missing-proto-and-host", "foobar");

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,7 +3,7 @@ function template_service(service_name: string, interface_name: string, value: s
 }
 
 function template_external_url(input_url: string) {
-  return `EXTERNAL_URL_${input_url.toUpperCase().replace(/\./g, "_")}`;
+  return `EXTERNAL_URL_${input_url.toUpperCase().replace(/\./g, "_").replace(/-/g, "_")}`;
 }
 
 function get_var(env_var: string) {


### PR DESCRIPTION
# JIRA
https://clever.atlassian.net/browse/INFRANG-6523

# About
External URLs with a hyphen in the name were broken because the injected env var replaced the hyphen with an underscore, but the discovery code did not. Apps that have already worked around this bug by adding a `_` to the input URL will not be affected by the library update and can be patched at any time safely. 

# Testing
I've written some unit tests to ensure expected behavior.